### PR TITLE
Cause EOF and Ctrl-D to exit the CLI

### DIFF
--- a/src/Docs/CLI/Evaluate.hs
+++ b/src/Docs/CLI/Evaluate.hs
@@ -351,7 +351,7 @@ interactive = do
   viewInTerminal greeting
   loop $ do
     printContext
-    input <- fromMaybe "" <$> getInputLine "> "
+    input <- fromMaybe ":quit" <$> getInputLine "> "
     evaluate input
   where
     onError = return $ Right ()


### PR DESCRIPTION
Hello! Loving the tool so far, looking into a few tweaks to help make things a bit more scriptable; I'll try to break them up into manageable chunks :)

This first one is very simple and causes hdc to respect the "EOF" input, which, in almost all CLIs (including ghci). Many folks will have Ctrl-D muscle-memory to exit things, and now it'll work :)

It also allows you to script hdc much more easily from the CLI using stdin, since you can do things like `pbpaste | hdc` and it will run a query and quit. Currently it gets stuck in an infinite loop.