### PR TITLE
Add support for reading file URI's

### DIFF
--- a/src/Docs/CLI/Evaluate.hs
+++ b/src/Docs/CLI/Evaluate.hs
@@ -1052,9 +1052,7 @@ packageModuleUrl (PackageUrl purl) moduleName =
 -- | Fetch and cache request's content
 fetchHTML :: HasUrl a => a -> M HtmlPage
 fetchHTML x = do
-  cache <- State.gets sCache
-  let uri = getUrl x
-  src <- cached cache uri $ fetch uri
+  src <- fetch (getUrl x)
   return (parseHtmlDocument src)
 
 -- | Decide how to fetch depending on the URI
@@ -1073,6 +1071,8 @@ fetchFile filePath = do
 
 fetchHttp :: Http.Request -> M LB.ByteString
 fetchHttp req = do
+  cache <- State.gets sCache
+  cached cache (show req) $ do
       liftIO $ hPutStrLn stderr $ "fetching: " <> uriToString id (Http.getUri req) ""
       manager <- State.gets sManager
       eitherRes <- liftIO $ try $ Http.httpLbs req manager

--- a/src/Docs/CLI/Evaluate.hs
+++ b/src/Docs/CLI/Evaluate.hs
@@ -215,7 +215,7 @@ runSearch term = do
       , ("start", Just "1")
       , ("hoogle", Just $ Text.encodeUtf8 $ Text.pack term)
       ]
-  res <- fetch req
+  res <- fetchHttp req
   either error return $ Aeson.eitherDecode res
 
 withFirstSearchResult
@@ -1046,20 +1046,33 @@ packageModuleUrl (PackageUrl purl) moduleName =
     stripSuffix x s = maybe s reverse $ stripPrefix x $ reverse s
 
 -- =============================
---  HTTP requests
+--  Fetch HTML
 -- =============================
 
+-- | Fetch and cache request's content
 fetchHTML :: HasUrl a => a -> M HtmlPage
 fetchHTML x = do
-  req <- Http.parseRequest (getUrl x)
-  src <- fetch req
+  cache <- State.gets sCache
+  let uri = getUrl x
+  src <- cached cache uri $ fetch uri
   return (parseHtmlDocument src)
 
--- | Fetch and cache request's content
-fetch :: Http.Request -> M LB.ByteString
-fetch req = do
-  cache <- State.gets sCache
-  cached cache (show req) $ do
+-- | Decide how to fetch depending on the URI
+fetch :: Url -> M LB.ByteString
+fetch uri | "https://" `isPrefixOf` uri 
+          || "http://" `isPrefixOf` uri = do 
+      req <- Http.parseRequest uri
+      fetchHttp req
+fetch uri | Just filePath <- stripPrefix "file://" uri = fetchFile filePath
+fetch uri = throwError $ "unable to parse URI pattern: " <> uri
+
+fetchFile :: FilePath -> M LB.ByteString
+fetchFile filePath = do
+      liftIO $ hPutStrLn stderr $ "reading file: " <> filePath
+      liftIO $ LB.readFile filePath
+
+fetchHttp :: Http.Request -> M LB.ByteString
+fetchHttp req = do
       liftIO $ hPutStrLn stderr $ "fetching: " <> uriToString id (Http.getUri req) ""
       manager <- State.gets sManager
       eitherRes <- liftIO $ try $ Http.httpLbs req manager


### PR DESCRIPTION
First of all, this is a REALLY nice program! I was previously quite annoyed at how bad the cli experience was for hoogle and hackage, and just resorted to using the browser. But this is really good! I haven't used it much, but it was already easier to use, than opening a web page, while I made this change :)

My change is adding support for handling file uri's, which is necessary when using a local Hoogle server. 
Some url's are changed to file uri's on a local Hoogle server. This made haskell-docs-cli crash when trying to open one of those. 
This change makes it so that haskell-docs-cli instead reads the file contents, and continues.

Considerations:
1. Would it make sense to change the Url type name to Uri? 
2. In my implementation I throw and error, if the uri cannot be parsed (if it does not start with `file://` or `http[s]://`. If there can be any links that either start with something else (maybe `ftp://hackage.haskell.org/.../...`), or does not start with any uri-type (eg. `hackage.haskell.org/.../...`), it will fail. 
    - We could instead default to `fetchHttp`, which would make sure it does not crash on something now, which it did not crash on before.