### PR TITLE
Updated error message to inform about `EDITOR` var

### DIFF
--- a/src/Docs/CLI/Evaluate.hs
+++ b/src/Docs/CLI/Evaluate.hs
@@ -918,7 +918,7 @@ viewSource durl = do
 getEditor :: IO String
 getEditor = getEnv "EDITOR" <|> getEnv "VISUAL" <|> defaultEditor
   where
-    defaultEditor = error "no editor selected"
+    defaultEditor = error "no editor selected, make sure you have 'EDITOR' environment variable defined for your shell"
 
 moduleResult :: (String, Hoogle.Item -> Maybe Hoogle.Module)
 moduleResult = ("module", toModule)


### PR DESCRIPTION
As a new comer, I had to look into source to see where was the actual issue. `no editor selected` is vague.

Either this or `README` can be updated to inform to define `EDITOR` environment variable.