### PR TITLE
Make tests run in Windows CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -27,8 +27,8 @@ jobs:
         id: setup
         with:
           ghc-version: ${{ matrix.ghc-version }}
+          cabal-version: '3.14.2.0'
           # Defaults, added for clarity:
-          cabal-version: 'latest'
           cabal-update: true
 
       - name: Configure the build

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,6 +13,9 @@ jobs:
   build:
     name: GHC ${{ matrix.ghc-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
     strategy:
       fail-fast: false
       matrix:
@@ -68,7 +71,6 @@ jobs:
         run: ./test/test.sh
 
       - name: Create package
-        shell: bash
         run: |
           mkdir haskell-docs-cli
           binary=$(cabal list-bin hdc)

--- a/test/test.sh
+++ b/test/test.sh
@@ -53,6 +53,8 @@ function run_test() {
 
   # Run the command
   eval "$COMMAND" &>$TMP
+
+  # Compare output (actual in file $TMP vs. expected in file $OUTPUT)
   diff $TMP $OUTPUT && R=true || R=false;
 
   # Report the result

--- a/test/test.sh
+++ b/test/test.sh
@@ -6,6 +6,8 @@
 #
 # Re-generating the files is straight-forward (see boolean flags in tests).
 # New test files can be generated using the same method.
+#
+# To debug the script, add a line `set -x` to enable execution tracing.
 
 set -euo pipefail
 
@@ -46,13 +48,22 @@ function run_test() {
   COMMAND="${2}"
   OUTPUT="${3}"
 
+  # run `hdc` in subprocess with `set +x`
+  # (= tracing unconditionally disabled so it won't interfere with stderr)
+
   # Update output file
   if [ "$UPDATE" = true ] ; then
+    (
+    set +x
     eval "$COMMAND" &>$OUTPUT
+    )
   fi
 
   # Run the command
+  (
+  set +x
   eval "$COMMAND" &>$TMP
+  )
 
   # Compare output (actual in file $TMP vs. expected in file $OUTPUT)
   diff $TMP $OUTPUT && R=true || R=false;

--- a/test/test.sh
+++ b/test/test.sh
@@ -31,6 +31,13 @@ function hdc() {
   set -u
 }
 
+function diff_() {
+  diff --ignore-space-change "$@"
+  }
+  # about `--ignore-space-change`:
+  # - to make tests pass on Windows CI (a subtle hdc bug causes output on Windows to sometimes have extra Carriage Return characters at the end of the line)
+  # - supported by `diff` on all CI platforms: linux/ubuntu (GNU diffutils), Windows (GNU diffutils through MSYS2 through Git Bash), macOS (BSD diff)
+
 # print coloured text
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -66,7 +73,7 @@ function run_test() {
   )
 
   # Compare output (actual in file $TMP vs. expected in file $OUTPUT)
-  diff $TMP $OUTPUT && R=true || R=false;
+  diff_ $TMP $OUTPUT && R=true || R=false;
 
   # Report the result
   if [ $R = true ]
@@ -88,6 +95,9 @@ function cleanup() {
 }
 
 trap cleanup EXIT
+
+# Early error if used diff invocation unsupported on current platform:
+diff_ /dev/null /dev/null || { echo 'FAILED (diff self-test)'; exit 1; }
 
 # Change the boolean flag to True to update test output
 run_test true "hdc --help" \


### PR DESCRIPTION
This fixes an issue with the Windows CI: the tests don't actually execute (but the workflow still succeeds).

Reason: Since no shell is specified for `run: ./test/test.sh`, Powershell is used by default which won't execute anything. This PR changes the default shell to `bash` so `bash` is used for all `run:` steps.

The PR also pins the cabal version which helps with making things more stable and reproducible.

The PR further changes the invocation of `diff` in the test script to `diff --ignore-space-change ..` - without that, the Windows tests actually fail. That's due to a real bug - but one that is tiny and shouldn't cause problems so this PR just hides it. This tiny bug is that on Windows, consequtive lines with `<pre>` causes the terminal output to have _two_ carriage returns at newlines instead of just one. Codewise I would suspect the culprit to be somewhere in the [Haddock.hs#L466:L470] expression. The repeated CR characters are enough to make the `diff` fail, but is worked around with `--ignore-space-change`. 

CI runs succesfully after this PR on my fork (https://github.com/carlwr/haskell-docs-cli/actions/runs/18103506110). And builds properly on my local machine (macOS).

[Haddock.hs#L466:L470]: https://github.com/lazamar/haskell-docs-cli/blob/943ee3bc9b8eac1a43534db4238be713b297e9d3/src/Docs/CLI/Haddock.hs#L466:L470